### PR TITLE
select() returns IODataQuery

### DIFF
--- a/lib/odata-query.ts
+++ b/lib/odata-query.ts
@@ -74,9 +74,9 @@ export class ODataQuery<
         return this.create(part);
     }
 
-    public select<K extends keyof T>(...names: K[]): PromiseLike<Result<Array<Pick<T, K>>, TExtra>> {
+    public select<K extends keyof T>(...names: K[]): IODataQuery<Pick<T, K>, TExtra> {
         const part = new QueryPart(ODataFuncs.oDataSelect, [PartArgument.literal(names)]);
-        return this.provider.executeAsync([...this.parts, part]);
+        return this.create(part);
     }
 
     public groupBy<TKey extends object, TResult extends object>(
@@ -183,7 +183,7 @@ export interface IODataQuery<T, TExtra = {}> extends IQueryBase {
     take(count: number): IODataQuery<T, TExtra>;
     cast(ctor: Ctor<T>): IODataQuery<T, TExtra>;
 
-    select<K extends keyof T>(...names: K[]): PromiseLike<Result<Array<Pick<T, K>>, TExtra>>;
+    select<K extends keyof T>(...names: K[]): IODataQuery<Pick<T, K>, TExtra>;
     groupBy<TKey extends object, TResult extends object>(
         keySelector: Func1<T, TKey>, elementSelector?: Func1<T[] & TKey, TResult>, ...scopes: any[])
         : PromiseLike<Result<TResult[], TExtra>>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jinqu-odata",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "description": "Jinqu OData implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/test/service.spec.ts
+++ b/test/service.spec.ts
@@ -195,9 +195,9 @@ describe("Service tests", () => {
     });
 
     it("should handle select", () => {
-        const promise = service.companies()
+        const query = service.companies()
             .select("id", "name");
-        expect(promise).to.be.fulfilled.and.eventually.be.null;
+        expect(query.toArrayAsync()).to.be.fulfilled.and.eventually.be.null;
 
         const url = provider.options.url;
         const expectedUrl = `api/Companies?$select=${encodeURIComponent("id,name")}`;


### PR DESCRIPTION
## Change list

select() returns IODataQuery instead of Promise.
It fixes the [issue # 42](https://github.com/jin-qu/jinqu-odata/issues/42) in the original repository
 
## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
